### PR TITLE
Compile on Ubuntu 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ In order to build, in addition to the base system, you must install:
 - ninja-build
 - clang
 - zlib1g-dev
+- libzstd-dev
 - dependencies for above
 - CMake 3.24 or higher.  Instructions are at https://apt.kitware.com/
 

--- a/lib/driver/DriverAction.cpp
+++ b/lib/driver/DriverAction.cpp
@@ -376,7 +376,7 @@ bool ExtractEntryPointAddressAction::runImpl(DriverContext &context) {
   }
 
   // Find the _qaic_start symbol within the elf
-  llvm::Optional<uint64_t> activateAddr;
+  std::optional<uint64_t> activateAddr;
   for (SymbolRef Sym : Object->symbols()) {
     auto type = Sym.getType();
     if (!type || type.get() != SymbolRef::ST_Function)
@@ -391,11 +391,11 @@ bool ExtractEntryPointAddressAction::runImpl(DriverContext &context) {
     }
   }
 
-  context.getProgram()->setEntrypointAddr(activateAddr.getValue());
-  QAIC_DEBUG_STREAM("found activate function at " << activateAddr.getValue()
+  context.getProgram()->setEntrypointAddr(activateAddr.value());
+  QAIC_DEBUG_STREAM("found activate function at " << activateAddr.value()
                                                   << "\n");
 
-  return activateAddr.hasValue();
+  return activateAddr.has_value();
 };
 
 BuildQPCAction::BuildQPCAction(Driver &D) : DriverAction(D, "BuildQPCAction") {}

--- a/lib/driver/DriverOptions.cpp
+++ b/lib/driver/DriverOptions.cpp
@@ -11,28 +11,50 @@ using namespace llvm::opt;
 using namespace qaic;
 using namespace qaic::options;
 
+#if LLVM_VERSION_MAJOR >= 16
+#define PREFIX(NAME, VALUE) static constexpr llvm::StringLiteral NAME[] = VALUE;
+#else
 #define PREFIX(NAME, VALUE) static const char *const NAME[] = VALUE;
+#endif
 #include "DriverOptions.inc"
 #undef PREFIX
 
-static const OptTable::Info InfoTable[] = {
+static constexpr OptTable::Info InfoTable[] = {
+#if LLVM_VERSION_MAJOR >= 18
+#define OPTION(...) LLVM_CONSTRUCT_OPT_INFO(__VA_ARGS__),
+#else
 #define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
                HELPTEXT, METAVAR, VALUES)                                      \
   {PREFIX, NAME,  HELPTEXT,    METAVAR,     OPT_##ID,  Option::KIND##Class,    \
    PARAM,  FLAGS, OPT_##GROUP, OPT_##ALIAS, ALIASARGS, VALUES},
+#endif
 #include "DriverOptions.inc"
 #undef OPTION
 };
 
+#if LLVM_VERSION_MAJOR >= 16
+static constexpr llvm::StringLiteral PrefixesUnion[] = {
+    llvm::StringLiteral("-"),
+    llvm::StringLiteral("--"),
+};
+#endif
+
 namespace {
 
-class DriverOptTable : public OptTable {
+class DriverOptTable final : public OptTable {
 public:
   DriverOptTable() : OptTable(InfoTable) {}
+
+#if LLVM_VERSION_MAJOR >= 16
+private:
+  llvm::ArrayRef<llvm::StringLiteral> getPrefixesUnion() const override {
+    return PrefixesUnion;
+  }
+#endif
 };
 } // namespace
 
-const llvm::opt::OptTable &Driver::getDriverOptTable() {
+const OptTable &Driver::getDriverOptTable() {
   static DriverOptTable Table;
   return Table;
 }

--- a/lib/driver/DriverOptions.h
+++ b/lib/driver/DriverOptions.h
@@ -15,9 +15,15 @@ namespace options {
  */
 enum ID {
   OPT_INVALID = 0,
-#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
-               HELPTEXT, METAVAR, VALUES)                                      \
+#if LLVM_VERSION_MAJOR >= 18
+#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, \
+               VISIBILITY, PARAM, HELPTEXT, METAVAR, VALUES)           \
   OPT_##ID,
+#else
+#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
+               HELPTEXT, METAVAR, VALUES) \
+  OPT_##ID,
+#endif
 #include "DriverOptions.inc"
 #undef OPTION
   LastOption,

--- a/lib/program/Program.cpp
+++ b/lib/program/Program.cpp
@@ -24,9 +24,11 @@ const uint32_t L2TCM_MAX_SIZE = 1 * 1024 * 1024; /*1MB L2TCM*/
 const uint32_t COMPUTE_MAX_SEMAPHORES = 2;
 const uint32_t DB_SIZE = 4; /*Bytes per doorbell*/
 
+#if LLVM_VERSION_MAJOR < 16
 static uint64_t alignTo(uint64_t x, uint64_t m) {
   return ((x + (m - 1)) & ~(m - 1)); // Only works if alignment is 2^n
 }
+#endif
 
 ComputeProgram::ComputeProgram(ProgramConfig &&config)
     : config_(std::move(config)), entryPoint_(0) {}

--- a/lib/toolchain/Compiler.cpp
+++ b/lib/toolchain/Compiler.cpp
@@ -77,7 +77,11 @@ void qaic::Compiler::addSystemIncludePath(llvm::StringRef path) {
 }
 
 void qaic::Compiler::addWarningFlag(llvm::StringRef flag) {
+#if LLVM_VERSION_MAJOR >= 18
+  if (flag.starts_with("-W")) {
+#else
   if (flag.startswith("-W")) {
+#endif
     warningFlags_.push_back(flag.str());
   } else {
     std::string arg = "-W";

--- a/lib/toolchain/Linker.cpp
+++ b/lib/toolchain/Linker.cpp
@@ -62,7 +62,11 @@ void qaic::Linker::endWholeArchive() {
 }
 
 void qaic::Linker::addLinkerSearchPath(llvm::StringRef path) {
+#if LLVM_VERSION_MAJOR >= 18
+  if (path.starts_with("-Wl,-L")) {
+#else
   if (path.startswith("-Wl,-L")) {
+#endif
     path.consume_front("-Wl,-L");
   }
   std::string arg = "-Wl,-L";

--- a/lib/toolchain/Tools.cpp
+++ b/lib/toolchain/Tools.cpp
@@ -15,22 +15,34 @@ using namespace llvm;
 #define DEBUG_TYPE "toolchain"
 
 bool qaic::Toolset::isEmptyToolset() const {
-  return (!CC.hasValue() && !CXX.hasValue() && !LD.hasValue() &&
-          !AR.hasValue() && !Objcopy.hasValue());
+  return (!CC.has_value() && !CXX.has_value() && !LD.has_value() &&
+          !AR.has_value() && !Objcopy.has_value());
 }
 
 void qaic::Tools::loadStandardEnvPaths() {
   // Add hexagon tools dir if defined
+#if LLVM_VERSION_MAJOR >= 18
   auto hexToolsDir = sys::Process::GetEnv("HEXAGON_TOOLS_DIR");
-  if (hexToolsDir.hasValue()) {
-    setHexagonToolsPath(hexToolsDir.getValue() + "/bin");
+#else
+  auto hexenv = sys::Process::GetEnv("HEXAGON_TOOLS_DIR");
+  std::optional<std::string> hexToolsDir = *hexenv;
+#endif
+
+  if (hexToolsDir.has_value()) {
+    setHexagonToolsPath(hexToolsDir.value() + "/bin");
   }
 
   // Add PATHs to tool search
+#if LLVM_VERSION_MAJOR >= 18
   auto pathEnv = sys::Process::GetEnv("PATH");
-  if (pathEnv.hasValue()) {
+#else
+  auto penv = sys::Process::GetEnv("PATH");
+  std::optional<std::string> pathEnv = *penv;
+#endif
+
+  if (pathEnv.has_value()) {
     SmallVector<StringRef, 16> paths;
-    SplitString(pathEnv.getValue(), paths,
+    SplitString(pathEnv.value(), paths,
                 std::string("") + sys::EnvPathSeparator);
     for (auto &s : paths) {
       addSearchPath(s);
@@ -90,26 +102,26 @@ qaic::Tools::findProgramByName(StringRef program,
 
 ErrorOr<std::string> qaic::Tools::findCCompiler() const {
   std::vector<StringRef> paths = getSearchPaths();
-  return findProgramByName(hexagonToolset_.CC.getValueOr("clang"), paths);
+  return findProgramByName(hexagonToolset_.CC.value_or("clang"), paths);
 }
 
 ErrorOr<std::string> qaic::Tools::findCXXCompiler() const {
   std::vector<StringRef> paths = getSearchPaths();
-  return findProgramByName(hexagonToolset_.CXX.getValueOr("clang++"), paths);
+  return findProgramByName(hexagonToolset_.CXX.value_or("clang++"), paths);
 }
 
 ErrorOr<std::string> qaic::Tools::findLinker() const {
   std::vector<StringRef> paths = getSearchPaths();
-  return findProgramByName(hexagonToolset_.LD.getValueOr("llvm-link"), paths);
+  return findProgramByName(hexagonToolset_.LD.value_or("llvm-link"), paths);
 }
 
 ErrorOr<std::string> qaic::Tools::findAr() const {
   std::vector<StringRef> paths = getSearchPaths();
-  return findProgramByName(hexagonToolset_.AR.getValueOr("llvm-ar"), paths);
+  return findProgramByName(hexagonToolset_.AR.value_or("llvm-ar"), paths);
 }
 
 ErrorOr<std::string> qaic::Tools::findObjcopy() const {
   std::vector<StringRef> paths = getSearchPaths();
   return findProgramByName(
-        hexagonToolset_.Objcopy.getValueOr("llvm-objcopy"), paths);
+        hexagonToolset_.Objcopy.value_or("llvm-objcopy"), paths);
 }

--- a/lib/toolchain/Tools.h
+++ b/lib/toolchain/Tools.h
@@ -4,22 +4,22 @@
 #ifndef _QAIC_TOOLCHAIN_TOOLS_H_
 #define _QAIC_TOOLCHAIN_TOOLS_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
 #include "llvm/ADT/APInt.h"
-#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorOr.h"
 
 namespace qaic {
 
 struct Toolset {
-  llvm::Optional<std::string> CC;
-  llvm::Optional<std::string> CXX;
-  llvm::Optional<std::string> LD;
-  llvm::Optional<std::string> AR;
-  llvm::Optional<std::string> Objcopy;
+  std::optional<std::string> CC;
+  std::optional<std::string> CXX;
+  std::optional<std::string> LD;
+  std::optional<std::string> AR;
+  std::optional<std::string> Objcopy;
 
   /// Returns true if no tool is set
   bool isEmptyToolset() const;

--- a/test/unittest/ToolchainToolsTest.cpp
+++ b/test/unittest/ToolchainToolsTest.cpp
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 
 #include "toolchain/Tools.h"
-#include "llvm/Support/Host.h"
 
 using namespace qaic;
 


### PR DESCRIPTION
Port deprecated llvm-14 api to use llvm-18, the default for Ubuntu 24. Also retain backwards compatibility for Ubuntu 22 (llvm-14 - llvm-18).